### PR TITLE
feat: Make Homebrew optional to fix build failures and reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,8 +114,27 @@ RUN mkdir -p ${PNPM_HOME} && chown -R moltbot:moltbot /home/moltbot/.local
 
 USER moltbot
 
-# Install Homebrew (Linuxbrew) - must be done as non-root user
-RUN NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" || true
+# =============================================================================
+# HOMEBREW (LINUXBREW) - TEMPORARILY DISABLED
+# =============================================================================
+# Homebrew installation is commented out to reduce image size from ~2.5GB to ~1GB.
+#
+# Why disabled:
+# - Docker builds were failing both locally (ARM64 emulation timeout) and in
+#   GitHub Actions (exceeded 30-minute timeout during Homebrew installation)
+# - Homebrew adds ~1.5GB to the final image size
+# - Most users don't need runtime package installation via brew
+#
+# Impact:
+# - Users cannot run `brew install <package>` at runtime
+# - The 30-reinstall-brews init script will skip gracefully (no errors)
+# - All core functionality (moltbot, Tailscale, Spaces persistence) works normally
+#
+# To re-enable Homebrew, uncomment the following line:
+# RUN NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" || true
+#
+# TODO: Re-enable Homebrew in a future release with optimized build process
+# =============================================================================
 
 # Install nvm, Node.js LTS, pnpm, and moltbot
 RUN export SHELL=/bin/bash  && export NVM_DIR="$HOME/.nvm" \

--- a/rootfs/etc/cont-init.d/30-reinstall-brews
+++ b/rootfs/etc/cont-init.d/30-reinstall-brews
@@ -1,5 +1,12 @@
 #!/command/with-contenv bash
-# Reinstall Brews for all users (only when persistence is enabled)
+# Reinstall Brews for all users (only when persistence is enabled AND Homebrew is installed)
+
+# Skip if Homebrew is not installed
+# Homebrew is optional in this image to reduce size (~1.5GB savings)
+if [ ! -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+  echo "[reinstall-brews] Homebrew not installed, skipping"
+  exit 0
+fi
 
 # Skip if persistence is not configured
 if [ "${ENABLE_SPACES:-false}" != "true" ]; then

--- a/rootfs/etc/profile.d/homebrew.sh
+++ b/rootfs/etc/profile.d/homebrew.sh
@@ -1,1 +1,5 @@
-eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+# Homebrew (Linuxbrew) shell environment setup
+# Only load if Homebrew is installed - it's optional in this image
+if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+fi


### PR DESCRIPTION
## Problem

Docker image builds have been consistently failing:

### 1. GitHub Actions Timeout
Build exceeded **30-minute timeout** during Homebrew installation step. The Homebrew installer downloads and compiles numerous dependencies, which is extremely slow in CI environments.

### 2. Local Build Failures
ARM64 emulation on macOS (via Docker Desktop/OrbStack) causes the build to **hang or timeout** during Homebrew installation due to QEMU emulation overhead. We could not successfully build the image locally.

### 3. Image Size Impact
Homebrew adds approximately **1.5GB** to the final image:
- Without Homebrew: ~1GB
- With Homebrew: ~2.5GB

This impacts container pull times, storage costs, and cold start performance on App Platform.

## Solution

Make Homebrew installation **optional** by commenting it out in the Dockerfile. This is a **temporary measure** until we can optimize the build process in the coming weeks.

## Changes

### 1. `Dockerfile`
- Comment out Homebrew installation
- Add detailed documentation explaining why it's disabled
- Include instructions for users who want to re-enable it

### 2. `rootfs/etc/profile.d/homebrew.sh`
- Make conditional: only loads Homebrew shell environment if brew is actually installed
- **Prevents errors** on shell login when Homebrew is not present

### 3. `rootfs/etc/cont-init.d/30-reinstall-brews`
- Add check for Homebrew installation at the start
- Script gracefully skips with a clear message: `[reinstall-brews] Homebrew not installed, skipping`

## User Experience Impact

| Feature | Status | Notes |
|---------|--------|-------|
| moltbot gateway | ✅ Works | No change |
| Tailscale | ✅ Works | No change |
| Spaces persistence | ✅ Works | No change |
| ngrok tunnel | ✅ Works | No change |
| SSH access | ✅ Works | No change |
| Shell login | ✅ Works | No errors (conditional profile) |
| `brew install X` | ❌ Not available | Command not found |
| Package restore | ⚠️ Skipped | Graceful skip, no errors |

**All core functionality remains intact.** Users simply cannot install additional packages via `brew install` at runtime.

## Future Work

We plan to re-enable Homebrew in the coming weeks with one of these approaches:
- Pre-build Homebrew in a separate Docker layer/stage
- Use a Homebrew bottle cache for faster installation
- Investigate faster alternatives (nix, pkgx)
- Increase GitHub Actions timeout and use native ARM runners

## Test Plan

- [ ] GitHub Actions build completes successfully (should be much faster now)
- [ ] Container starts without errors
- [ ] Shell login works without brew-related errors
- [ ] `[reinstall-brews] Homebrew not installed, skipping` appears in logs
- [ ] All core features work (moltbot, Tailscale, Spaces, ngrok)