### PR TITLE
fix: Suppress restic stderr when checking repository existence

### DIFF
--- a/rootfs/etc/cont-init.d/05-setup-restic
+++ b/rootfs/etc/cont-init.d/05-setup-restic
@@ -72,7 +72,7 @@ done < <(env | grep -E '^RESTIC_')
 
 # Initialize restic repo if it doesn't exist
 echo "[setup-restic] Checking if restic repository exists..."
-if restic snapshots | tail -n 20 2>/dev/null; then
+if restic snapshots 2>/dev/null | tail -n 20; then
   echo "[setup-restic] Restic repository already initialized"
 else
   echo "[setup-restic] Initializing restic repository..."


### PR DESCRIPTION
## Summary
- Move `2>/dev/null` to apply to `restic snapshots` command instead of `tail`
- Prevents confusing "Fatal: repository does not exist" error from displaying during normal first-run initialization

## Test plan
- [ ] Deploy container with no existing restic repository
- [ ] Verify no error message appears during initialization
- [ ] Verify repository is still initialized correctly