### PR TITLE
refactor: Rename ENABLE_SSH to SSH_ENABLE

### DIFF
--- a/.do/deploy.template-ghcr.yaml
+++ b/.do/deploy.template-ghcr.yaml
@@ -80,7 +80,7 @@ spec:
         - key: MOLTBOT_GATEWAY_TOKEN
           scope: RUN_TIME
           type: SECRET
-        - key: ENABLE_SSH
+        - key: SSH_ENABLE
           scope: RUN_TIME
           value: "false"
         - key: GITHUB_USERNAME

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -69,7 +69,7 @@ spec:
         - key: MOLTBOT_GATEWAY_TOKEN
           scope: RUN_TIME
           type: SECRET
-        - key: ENABLE_SSH
+        - key: SSH_ENABLE
           scope: RUN_TIME
           value: "false"
         - key: GITHUB_USERNAME

--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@ RESTIC_PASSWORD=ChangeMe
 # ============================================================
 MOLTBOT_GATEWAY_TOKEN=
 GRADIENT_API_KEY=
-ENABLE_SSH=false
+SSH_ENABLE=false
 GITHUB_USERNAME=
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           ENABLE_TAILSCALE=false
           ENABLE_NGROK=false
           ENABLE_SPACES=false
-          ENABLE_SSH=false
+          SSH_ENABLE=false
           STABLE_HOSTNAME=moltbot-test
           # Keep container running even if services fail (0=continue, 1=SIGTERM, 2=SIGKILL)
           S6_BEHAVIOUR_IF_STAGE2_FAILS=0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ The container uses [s6-overlay](https://github.com/just-containers/s6-overlay) f
 - `tailscale/` - Tailscale daemon (if ENABLE_TAILSCALE=true)
 - `moltbot/` - OpenClaw gateway
 - `ngrok/` - ngrok tunnel (if ENABLE_NGROK=true)
-- `sshd/` - SSH server (if ENABLE_SSH=true)
+- `sshd/` - SSH server (if SSH_ENABLE=true)
 - `backup/` - Periodic Restic backup service (if ENABLE_SPACES=true)
 - `prune/` - Periodic Restic snapshot cleanup (if ENABLE_SPACES=true)
 - `crond/` - Cron daemon for scheduled tasks

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Deploy [OpenClaw](https://github.com/moltbot/moltbot) - a multi-channel AI messa
 │  │  • Tailscale (ENABLE_TAILSCALE) - Private network            │  │
 │  └──────────────────────────────────────────────────────────────┘  │
 │  ┌──────────────────────────────────────────────────────────────┐  │
-│  │ Optional: SSH Server (ENABLE_SSH=true)                       │  │
+│  │ Optional: SSH Server (SSH_ENABLE=true)                        │  │
 │  └──────────────────────────────────────────────────────────────┘  │
 └────────────────────────────────────────────────────────────────────┘
          │                    │                    │
@@ -311,7 +311,7 @@ See **[CHEATSHEET.md](CHEATSHEET.md)** for the complete reference.
 | `ENABLE_TAILSCALE` | `false` | Enable Tailscale |
 | `ENABLE_SPACES` | `false` | Enable DO Spaces persistence |
 | `ENABLE_UI` | `true` | Enable web Control UI |
-| `ENABLE_SSH` | `false` | Enable SSH server |
+| `SSH_ENABLE` | `false` | Enable SSH server |
 
 ### ngrok (when ENABLE_NGROK=true)
 

--- a/app-ghcr.yaml
+++ b/app-ghcr.yaml
@@ -98,7 +98,7 @@ workers:
       - key: GRADIENT_API_KEY
         scope: RUN_TIME
         type: SECRET
-      - key: ENABLE_SSH
+      - key: SSH_ENABLE
         scope: RUN_TIME
         value: "false"
       - key: GITHUB_USERNAME

--- a/app.yaml
+++ b/app.yaml
@@ -89,7 +89,7 @@ workers:
       - key: GRADIENT_API_KEY
         scope: RUN_TIME
         type: SECRET
-      - key: ENABLE_SSH
+      - key: SSH_ENABLE
         scope: RUN_TIME
         value: "false"
       - key: GITHUB_USERNAME

--- a/rootfs/etc/services.d/sshd/run
+++ b/rootfs/etc/services.d/sshd/run
@@ -1,8 +1,8 @@
 #!/command/with-contenv bash
-# SSH server (optional, enabled via ENABLE_SSH=true)
+# SSH server (optional, enabled via SSH_ENABLE=true)
 
-if [ "${ENABLE_SSH:-false}" != "true" ]; then
-  echo "[sshd] SSH disabled (set ENABLE_SSH=true to enable)"
+if [ "${SSH_ENABLE:-false}" != "true" ]; then
+  echo "[sshd] SSH disabled (set SSH_ENABLE=true to enable)"
   # Mark this service as down so s6 doesn't restart it
   s6-svc -Od .
   exit 0


### PR DESCRIPTION
## Summary
- Rename `ENABLE_SSH` environment variable to `SSH_ENABLE` for naming consistency

## Test plan
- [ ] Verify SSH service still responds to the new env var name
- [ ] Deploy and confirm SSH can be enabled/disabled via `SSH_ENABLE`